### PR TITLE
Pages migration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,10 +21,13 @@ task :serve do
 end
 
 task :upload => :build do
-  current_branch = `git branch 2>/dev/null | awk '/^\* /{print $2}'`
-  sh "git checkout gh-pages"
-  sh "cp -R .html/.* ."
-  sh "git add ."
-  sh "git commit -m 'P U B L I S H'"
-  sh "git checkout #{current_branch}"
+  current_branch = `git branch 2>/dev/null | awk '/^\* /{print $2}'`.strip
+  ["git checkout gh-pages",
+   "rsync -rv .html/.* .",
+   "git add .",
+   "[[ -z `git status --porcelain` ]] || (git commit -m 'P U B L I S H' ; git push -f)",
+   "git checkout #{current_branch}"].all? do |cmd|
+                                     # We use all? so that we'll abort if anything fails.
+     sh cmd, verbose: true
+   end
 end


### PR DESCRIPTION
Changes the `rake upload` task to one that pushes a compiled version of the site to a  `gh-pages` branch. This way, anyone with push access to the repo can publish the site instead of a few folks with access to dreamhost.

You can see this in action at http://unlicense.github.io/unlicense.org/, or add `192.30.252.153 unlicense.org www.unlicense.org` to your hosts file and hit the URL directly.

To use this, `unlicense.org` would have to point to GitHub pages as per https://help.github.com/articles/setting-up-a-custom-domain-with-pages. The tldr is 'two A records to 192.30.252.153 and 192.30.252.154'.
