### PR TITLE
Fix missing underlines on https links

### DIFF
--- a/.templates/document.html
+++ b/.templates/document.html
@@ -46,6 +46,9 @@
     background-color: #F6F6F6;
     text-align: center;
   }
+  a {
+    text-decoration: underline;
+  }
 </style>
 <link href="https://plus.google.com/117796491719586050994" rel="publisher"/>
 {% endblock %}


### PR DESCRIPTION
This should fix the issue with missing underlines on https links described in #30.
