### PR TITLE
update Github search link

### DIFF
--- a/wiki/index
+++ b/wiki/index
@@ -256,7 +256,7 @@ Find and follow us on
 
 [anti-copyright]:     http://en.wikipedia.org/wiki/Anti-copyright
 [Google Search]:      http://www.google.com/search?q=%22This+is+free+and+unencumbered+software+released+into+the+public+domain%22&filter=0
-[GitHub]:             https://github.com/search?q=path%3AUNLICENSE&type=Code&s=indexed
+[GitHub]:             https://github.com/search?q=license%3Aunlicense
 [Bitbucket]:          http://www.google.com/search?q=%22This+is+free+and+unencumbered+software+released+into+the+public+domain%22+site%3Abitbucket.org&filter=0
 
 <script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>


### PR DESCRIPTION
The Github search now has a feature to search for repositories with a certain license type.

~I furthermore suggest to update this paragraph:~

> ~You would traditionally put the above statement into a file named COPYING or LICENSE. However, to explicitly distance yourself from the whole concept of copyright licensing, we recommend that you put your unlicensing statement in a file named UNLICENSE. Doing so also means that your project can more easily be found on e.g. GitHub or Bitbucket, enabling others to reuse your code in their own unencumbered public domain projects.~

~I'm not sure whether Github would be able to auto-detect the license type as "Unlicense" if the file is not called `license`/`license.md`. If you want me to update that as well, you can just let me know before merging this and I'll make a suggestion :nerd_face:~