### PR TITLE
Remove google plus buttons

### DIFF
--- a/wiki/index
+++ b/wiki/index
@@ -13,9 +13,6 @@ Unlicense Yourself: Set Your Code Free
 <span id="facebook-like-button">
 <iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Funlicense.org%2F&amp;send=false&amp;layout=button_count&amp;width=90&amp;show_faces=true&amp;font&amp;colorscheme=light&amp;action=like&amp;height=21&amp;appId=144905262363906" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:90px; height:21px;" allowTransparency="true"></iframe>
 </span>
-<span id="google-plus-button">
-<g:plusone href="http://unlicense.org/" size="medium" annotation="bubble"></g:plusone>
-</span>
 <span id="tumblr-follow-button">
 <iframe class="btn" frameborder="0" border="0" scrolling="no" allowtransparency="true" height="25" width="115" src="https://platform.tumblr.com/v1/follow_button.html?button_type=2&tumblelog=unlicense&color_scheme=dark"></iframe>
 </span>
@@ -250,7 +247,6 @@ If setting your code entirely free still seems a somewhat daunting prospect, try
 Find and follow us on
 <a href="https://twitter.com/theunlicense">Twitter</a>,
 <a href="https://www.facebook.com/TheUnlicense">Facebook</a>,
-<a href="https://plus.google.com/117796491719586050994" rel="publisher">Google+</a>,
 <a href="http://www.reddit.com/r/unlicense/">Reddit</a>, and
 <a href="http://unlicense.tumblr.com">Tumblr</a>.
 
@@ -258,5 +254,3 @@ Find and follow us on
 [Google Search]:      http://www.google.com/search?q=%22This+is+free+and+unencumbered+software+released+into+the+public+domain%22&filter=0
 [GitHub]:             https://github.com/search?q=license%3Aunlicense
 [Bitbucket]:          http://www.google.com/search?q=%22This+is+free+and+unencumbered+software+released+into+the+public+domain%22+site%3Abitbucket.org&filter=0
-
-<script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>


### PR DESCRIPTION
G+ was discontinued a few months ago, all the links that point there are dead now.

See https://en.wikipedia.org/wiki/Google%2B#Shutdown_of_consumer_version