### PR TITLE
Remove tracking buttons

### DIFF
--- a/wiki/index
+++ b/wiki/index
@@ -1,26 +1,6 @@
 Unlicense Yourself: Set Your Code Free
 ======================================
 
-<div id="buttons">
-<span id="twitter-follow-button">
-<a href="https://twitter.com/theunlicense" class="twitter-follow-button" data-show-count="false">Follow @theunlicense</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-</span>
-<span id="twitter-tweet-button">
-<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://unlicense.org/" data-via="theunlicense">Tweet</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-</span>
-<span id="facebook-like-button">
-<iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Funlicense.org%2F&amp;send=false&amp;layout=button_count&amp;width=90&amp;show_faces=true&amp;font&amp;colorscheme=light&amp;action=like&amp;height=21&amp;appId=144905262363906" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:90px; height:21px;" allowTransparency="true"></iframe>
-</span>
-<span id="google-plus-button">
-<g:plusone href="http://unlicense.org/" size="medium" annotation="bubble"></g:plusone>
-</span>
-<span id="tumblr-follow-button">
-<iframe class="btn" frameborder="0" border="0" scrolling="no" allowtransparency="true" height="25" width="115" src="https://platform.tumblr.com/v1/follow_button.html?button_type=2&tumblelog=unlicense&color_scheme=dark"></iframe>
-</span>
-</div>
-
 What is the Unlicense?
 ----------------------
 


### PR DESCRIPTION
This just removes a bunch of buttons that required the inclusion of `<script>` and `<iframe>` tags that have been proved to be used for tracking[1].

Overall, the buttons don't seem to add much value, as the accounts that they point to have all been inactive for over a year[2], and having tracking in a website dedicated to anti-copyright doesn't go well according to my opinion.

This is an opinionated PR so if you, maintainers, think that it's not needed, feel free to just close it.

[1] https://en.wikipedia.org/wiki/Facebook_like_button#Tracking
[2] Inactivity periods:

| Social network | Inactivity Period          |
|----------------|----------------------------|
| Tumblr         | 5 years                    |
| Twitter        | 1 year                     |
| Reddit         | 4-5 years (+ there's spam) |
| Facebook       | 1 year                     |
| Google+        | Deprecated                 |