### PR TITLE
Add `Karabiner-Elements` for a link

### DIFF
--- a/wiki/index
+++ b/wiki/index
@@ -120,6 +120,7 @@ Here follows a sample of some of the software projects that have already adopted
 * [JSched](https://github.com/vladdu/jsched), a simple Java framework for coroutines.
 * [jStorage](http://www.jstorage.info), a cross-browser key-value store database to store data locally in the browser.
 * [Kakoune](https://github.com/mawww/kakoune), an experimental text editor heavily inspired by Vim.
+* [Karabiner-Elements](https://github.com/pqrs-org/Karabiner-Elements), utility for keyboard customization on macOS Sierra (10.12) or later.
 * [lein-cucumber](https://github.com/nilswloka/lein-cucumber), a simple Leiningen plugin for running Clojure-based Cucumber-JVM specifications.
 * [libcpr](https://github.com/dryproject/libcpr), a backport of the core data structures and algorithms from the C++11 standard library to C.
 * [loopozorg](https://github.com/narfdotpl/loopozorg), Python infrastructure for executing shell commands on file modification.


### PR DESCRIPTION
Hi! I believe https://github.com/pqrs-org/Karabiner-Elements is popular tool for Mac OS users. At least, it helps me a lot!

<img width="496" alt="スクリーンショット 2021-05-29 11 18 32" src="https://user-images.githubusercontent.com/1180335/120055233-9fcf5500-c06f-11eb-8cee-88af40614aae.png">


ref: https://github.com/pqrs-org/Karabiner-Elements/blob/537281fc588044cbb9a9c62f178d2df523058541/LICENSE.md